### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apk add --no-cache \
         gcc \
         git \
         linux-headers \
-        make
+        make \
+        perl
 
 ARG MAKE_JOBS
 WORKDIR /opt/itk-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Dockerfile for EvaluateSegmentation.
+#
+# Build image:
+#   docker build --tag evaluatesegmentation .
+#
+# Run image:
+#   docker run --rm -it -v $PWD:/data evaluatesegmentation /data/reference.nii.gz /data/segmentation.nii.gz
+
+ARG MAKE_JOBS=1
+
+FROM alpine:3.12.0 AS base
+FROM base AS builder
+
+RUN apk add --no-cache \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        linux-headers \
+        make
+
+ARG MAKE_JOBS
+WORKDIR /opt/itk-src
+RUN wget -O- -q https://github.com/InsightSoftwareConsortium/ITK/releases/download/v5.1.1/InsightToolkit-5.1.1.tar.gz \
+    | tar xz --strip 1 \
+    && mkdir build \
+    && cd build \
+    && cmake -DCMAKE_INSTALL_PREFIX=/opt/itk -DCMAKE_COLOR_MAKEFILE=OFF .. \
+    && make --jobs "$MAKE_JOBS" \
+    && make install
+
+WORKDIR /opt/evaluate-segmentation
+COPY . .
+RUN mkdir build \
+    && cd build \
+    && cmake -DITK_DIR=/opt/itk/lib/cmake/ITK-5.1 ../source \
+    && make --jobs "$MAKE_JOBS"
+
+FROM base
+COPY --from=builder /opt/evaluate-segmentation/build/EvaluateSegmentation /usr/local/bin/
+RUN apk add --no-cache libgcc libstdc++
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/EvaluateSegmentation"]
+CMD ["--help"]


### PR DESCRIPTION
Docker provides a standard method of installing software. This Dockerfile compiles and installs ITK and EvaluateSegmentation and allows users to easily build and use EvaluateSegmentation on any system with Docker, including Linux, macOS, and Windows.

I noticed the instructions to build ITK and this software were not complete, and the addition of this Dockerfile should make it easier for users to build and use this program.

This Docker image uses the Alpine Linux distribution to provide a lightweight image. The image is only 25.6 MB.

The image can be built with

```
docker build --tag evaluatesegmentation --build-arg MAKE_JOBS=6 .
```

The `MAKE_JOBS` argument provides `make --jobs=$MAKE_JOBS` for multi-process jobs. The default is a single-process make.

A pre-built image is available at `kaczmarj/evaluatesegmentation`

```
docker run --rm -it -v $PWD:/data kaczmarj/evaluatesegmentation /data/reference.nii.gz /data/segmentation.nii.gz
```